### PR TITLE
Fix crash with «$foo» returning singular item

### DIFF
--- a/t/06-cmd.t
+++ b/t/06-cmd.t
@@ -55,5 +55,5 @@ $osb.insert-cmd("b");
 $osc.insert-cmd("c");
 
 for < a b c > -> $cmd {
-    is &getopt(<< $cmd >>, $osa, $osb, $osc).optionset, {a => $osa, b => $osb, c => $osc}{$cmd}, "match cmd ok";
+    is &getopt(<< $cmd >>.List, $osa, $osb, $osc).optionset, {a => $osa, b => $osb, c => $osc}{$cmd}, "match cmd ok";
 }


### PR DESCRIPTION
The behaviour for what sort of object `«$foo»` returns when `$foo` does not contain whitespace was undefined.

Recently (rakudo 2018.01), it was clarified and defined to behave the same as `< >` brackets and to return a singular object rather than a `Slip`.

This change causes a crash in the tests, as the code is trying to pass a `Str` object for a `Positional` parameter.