### PR TITLE
add pre parser

### DIFF
--- a/doc/Getopt/Advance.adoc
+++ b/doc/Getopt/Advance.adoc
@@ -286,7 +286,7 @@ If an `OptionSet` match failed, consider follow serveral situation:
 
 * X::GA::ParseFailed
 +
-The `&parser` will call `&ga-try-next` throw an X::GA::ParseFailed exception
+The `&parser`(except `&ga-pre-parser`) will call `&ga-try-next` throw an X::GA::ParseFailed exception
 when `OptionSet` match failed. When `&getopt` caught this exception, it will
 try next `OptionSet` supplied. If no more `OptionSet`, it will print helper
 (when help generator `&helper` defined) of all `OptionSet`,  print error message,
@@ -570,8 +570,9 @@ Return an deep copy of current `OptionSet`.
 == `Argument`
 
 This is the command line argument, include the index and value.
-The `&parser` use non-option argument create `Argument`, and pass it to `cmd`,
-`pos` or `main`.
+The `&ga-parser` use non-option argument create `Argument`, and pass it to `cmd`,
+`pos` or `main`,
+and `&ga-pre-parser` pass all the left command line arguments to the `main`.
 
 === Method
 
@@ -859,11 +860,11 @@ Return an deep copy of current group.
 
 == `Parser`
 
-The `&ga-parser` will first check the options,
+The `&ga-parser` and `&ga-pre-parser` will first check the options,
 it will set the value provide by user when all option matched.
 Then check the options inside group.
-And next check cmd and pos, call its callback when matched.
-In the end, it will call all mains and return all the return value.
+And next check `cmd` and `pos`, call its callback when matched.
+In the end, it will call all `main`s and return all the return value.
 
 * sub ga-parser( @args, $optset,
     :$strict,
@@ -876,9 +877,29 @@ In the end, it will call all mains and return all the return value.
     :$x-style where :so,
     :$bsd-style,
     :$autohv ) of Getopt::Advance::ReturnValue
+
+* sub ga-pre-parser(
+    @args,
+    $optset,
+    :$strict,
+    :$x-style where :!so,
+    :$bsd-style,
+    :$autohv
+) of Getopt::Advance::ReturnValue
+
+* sub ga-pre-parser(
+    @args,
+    $optset,
+    :$strict,
+    :$x-style where :so,
+    :$bsd-style,
+    :$autohv
+) of Getopt::Advance::ReturnValue
 +
-Return the return value of each main except autohv
+`ga-parser` will return the return value of each main except autohv
 passed and user set `help` or `version` option.
+
+NOTE: `ga-pre-parser` only process `main` feature.
 
 
 == `Types`

--- a/t/15-preparser.t
+++ b/t/15-preparser.t
@@ -1,0 +1,34 @@
+
+use Test;
+use Getopt::Advance;
+use Getopt::Advance::Parser;
+
+my OptionSet $preos .= new;
+
+plan 6;
+
+$preos.push(
+    'w|weak=s',
+);
+$preos.push(
+    'p|pre=b',
+);
+
+my $ret = getopt(["-w", "weak", "-p", "-c", "42", "-q"], $preos, parser => &ga-pre-parser);
+
+ok $preos<p>, "set pre option ok";
+is $preos<w>, "weak", "set weak to \"weak\" ok";
+is $ret.noa, < -c 42 -q >, "get left command line argument";
+
+$preos.push(
+    'c|count=i',
+);
+$preos.push(
+    'q|quit=b',
+);
+
+$ret = getopt($ret.noa, $preos);
+
+ok $preos<q>, "set quit option ok";
+is $preos<c>, "42", "set count to 42 ok";
+is $ret.noa, [ ], "get left command line argument";


### PR DESCRIPTION
Add pre parser, it not throw exception when option match failed.
Not support `cmd` and `all` feature.
It will return all the command line arguments (not type Argument).
