### PR TITLE
Prevent tests from flapping

### DIFF
--- a/t/05-main.t
+++ b/t/05-main.t
@@ -23,12 +23,12 @@ getopt(
 );
 
 sub sum1($optset, @args) {
-    given @args.shift {
+    given @args[0] {
         when /plus/ {
-            is (sum @args>>.value>>.Int), 55, "plus ok";
+            is (sum @args[1..*]>>.value>>.Int), 55, "plus ok";
         }
         when /multi/ {
-            is ([*] @args>>.value>>.Int), 3628800, "multi ok";
+            is ([*] @args[1..*]>>.value>>.Int), 3628800, "multi ok";
         }
     }
 }


### PR DESCRIPTION
`sum1` and `sum2` can be called in any order, so calling `.shift` on
`@args` from `sum1` will modify the array for `sum2`, resulting in a
test failure. I don't know if this asyncness is intended, so someone
more knowledgeable should review.